### PR TITLE
Removed support for big endian byte order

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,18 +15,18 @@ Provided tools include:
 To build and run the tools, you will need to install the free and open source `.NET Core SDK 2.2`.
 
 Simply follow the "Build Apps" instructions relevant to your OS distribution:
-https://dotnet.microsoft.com/download
+> https://dotnet.microsoft.com/download
 
 ## Replay Server
 
 `replay-server` is a helpful application which plays back market data messages contained in data files.
 
-It listens for incoming TCP connections. Upon accepting a client, the `replay-server` immediately begins sending market data records one-by-one using the binary packet format defined in the coding assessment. Byte order of the wire packets can be specified as either `big` or `little` using command line argument.
+It listens for incoming TCP connections. Upon accepting a client, the `replay-server` immediately begins sending market data records one-by-one using the binary packet format defined in the coding assessment.
 
 ### Usage
 
 ```bash
-> dotnet run -p replay-server FILE.DAT PORT BYTE_ORDER
+> dotnet run -p replay-server FILE.DAT PORT
 ```
 
 where
@@ -35,13 +35,11 @@ where
 
 `PORT` - port to listen for connections on (ex: 65500)
 
-`BYTE_ORDER` - specifies whether the data on the wire should be encoded using `big` or `little` endian order. Valid values are `big` or `little`
-
 
 ### Example output
 
 ```text
-> dotnet run -p replay-server ./data/BTC-USD.dat 5000 big
+> dotnet run -p replay-server ./data/BTC-USD.dat 5000
 Accepting replay clients on: 0.0.0.0:5000
 ...snip...
 224606779726955|Q|BTC-USD|10688|32|10688|12
@@ -56,24 +54,20 @@ Accepting replay clients on: 0.0.0.0:5000
 
 `order-listener` is a simple application which accepts incoming connections, interprets the data as order messages, and prints them to screen. Use this tool to visualize orders transmitted by your application.
 
-Both `big` and `little` byte orders are supported. Simplify specify the mode on command line.
-
 ### Usage
 
 ```bash
-> dotnet run -p order-listener PORT BYTE_ORDER
+> dotnet run -p order-listener PORT
 ```
 
 where:
 
 `PORT` - port to listen for connections on (ex: `65511`)
 
-`BYTE_ORDER` - specifies whether the data on the wire is encoded using `big` or `little` endian order. Valid values are `big` or `little`
-
 ### Example output
 
 ```text
-> dotnet run -p order-listener 6000 little
+> dotnet run -p order-listener 6000
 Accepting order clients on: 0.0.0.0:6000
 Accepted connection: 127.0.0.1:52252
 <order timeStamp="1556564220920459606" symbol="BTC-USD" side="B" price="5006" size="89" />

--- a/order-listener/OrderListener.cs
+++ b/order-listener/OrderListener.cs
@@ -10,23 +10,18 @@ namespace Seed.CodingAssessment
     {
         static void Main(string[] args)
         {
-            if (args.Length != 2)
+            if (args.Length != 1)
             {
                 Console.WriteLine("Usage:");
-                Console.WriteLine("order-listener port byte_order");
+                Console.WriteLine("order-listener port");
                 Console.WriteLine();
                 Console.WriteLine("\tport - port to listen for connections on (ex: 65511)");
-                Console.WriteLine("\tbyte_order - whether data is encoded using 'big' or 'little' endian order");
-                Console.WriteLine("\t             valid values: 'big' or 'little'");
-                Console.WriteLine();
-                Console.WriteLine("Example:   65512 big");
                 Console.WriteLine();
                 Console.WriteLine();
                 Environment.Exit(1);
             }
 
             var port = int.Parse(args[0]);
-            var isDataBigEndian = !args[1].ToLowerInvariant().StartsWith('l');
 
             var tcpListener = new TcpListener(new IPEndPoint(IPAddress.Any, port));
             tcpListener.Start();
@@ -42,7 +37,7 @@ namespace Seed.CodingAssessment
                     Console.Error.WriteLine($"Accepted connection: {client.Client.RemoteEndPoint}");
 
                     using (var stream = client.GetStream())
-                    using (var reader = GetReader(stream, isDataBigEndian))
+                    using (var reader = new BinaryReader(stream, Encoding.ASCII, true))
                     {
                         while (client.Connected)
                         {
@@ -70,16 +65,6 @@ namespace Seed.CodingAssessment
 
                 Console.Error.WriteLine("client disconnected");
             }
-        }
-
-        static BinaryReader GetReader(Stream stream, bool bigEndian)
-        {
-            if (bigEndian)
-            {
-                return new Be.IO.BeBinaryReader(stream, Encoding.ASCII, true);
-            }
-
-            return new BinaryReader(stream, Encoding.ASCII, true);
         }
     }
 }

--- a/order-listener/order-listener.csproj
+++ b/order-listener/order-listener.csproj
@@ -3,12 +3,9 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>netcoreapp2.1</TargetFramework>
+        <RuntimeIdentifiers>linux-x64</RuntimeIdentifiers>
         <RootNamespace>Seed.CodingAssessment</RootNamespace>
         <AssemblyName>order-listener</AssemblyName>
     </PropertyGroup>
-
-    <ItemGroup>
-      <PackageReference Include="Be.IO-netstandard" Version="1.0.3" />
-    </ItemGroup>
 
 </Project>

--- a/replay-server/ReplayServer.cs
+++ b/replay-server/ReplayServer.cs
@@ -10,17 +10,15 @@ namespace Seed.CodingAssessment
     {
         static void Main(string[] args)
         {
-            if (args.Length != 3)
+            if (args.Length != 2)
             {
                 Console.WriteLine("Usage:");
-                Console.WriteLine("replay-server file.dat port byte_order");
+                Console.WriteLine("replay-server file.dat port");
                 Console.WriteLine();
                 Console.WriteLine("\tfile.dat - path to file containing market data to replay");
                 Console.WriteLine("\tport - port to listen for connections on (ex: 65511)");
-                Console.WriteLine("\tbyte_order - whether data is encoded using 'big' or 'little' endian order");
-                Console.WriteLine("\t             valid values: 'big' or 'little'");
                 Console.WriteLine();
-                Console.WriteLine("Example:   65511 big");
+                Console.WriteLine("Example: ./data/data.dat 65500");
                 Console.WriteLine();
                 Console.WriteLine();
                 Environment.Exit(1);
@@ -34,7 +32,6 @@ namespace Seed.CodingAssessment
             
             
             var port = int.Parse(args[1]);
-            var isDataBigEndian = !args[2].ToLowerInvariant().StartsWith('l');
 
             var tcpListener = new TcpListener(new IPEndPoint(IPAddress.Any, port));
             tcpListener.Start();
@@ -50,7 +47,7 @@ namespace Seed.CodingAssessment
                     Console.WriteLine($"Accepted connection: {client.Client.RemoteEndPoint}");
                     
                     using (var stream = client.GetStream())
-                    using (var writer = GetWriter(stream, isDataBigEndian))
+                    using (var writer = new BinaryWriter(stream, Encoding.ASCII, true))
                     {
                         foreach (var line in File.ReadLines(datFile.FullName))
                         {
@@ -74,16 +71,6 @@ namespace Seed.CodingAssessment
 
                 Console.WriteLine("client disconnected");
             }
-        }
-        
-        static BinaryWriter GetWriter(Stream stream, bool bigEndian)
-        {
-            if (bigEndian)
-            {
-                return new Be.IO.BeBinaryWriter(stream, Encoding.ASCII, true);
-            }
-
-            return new BinaryWriter(stream, Encoding.ASCII, true);
         }
     }
 }

--- a/replay-server/replay-server.csproj
+++ b/replay-server/replay-server.csproj
@@ -3,11 +3,8 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>netcoreapp2.1</TargetFramework>
+        <RuntimeIdentifiers>linux-x64</RuntimeIdentifiers>
         <RootNamespace>Seed.CodingAssessment</RootNamespace>
     </PropertyGroup>
-
-    <ItemGroup>
-      <PackageReference Include="Be.IO-netstandard" Version="1.0.3" />
-    </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Removed support for accepting and replaying data using the big
  endian byte order, since the assignment specifically asks for
  the wire format to be in little endian.

- Dropped big endian support nuget packages.

- Reworked the readme file.